### PR TITLE
Support executing one max concurrent operation

### DIFF
--- a/Source/PINOperationQueue.m
+++ b/Source/PINOperationQueue.m
@@ -94,7 +94,7 @@
 - (instancetype)initWithMaxConcurrentOperations:(NSUInteger)maxConcurrentOperations concurrentQueue:(dispatch_queue_t)concurrentQueue
 {
   if (self = [super init]) {
-    NSAssert(maxConcurrentOperations > 1, @"Max concurrent operations must be greater than 1. If it's one, just use a serial queue!");
+    NSAssert(maxConcurrentOperations > 0, @"Max concurrent operations must be greater than 0.");
     _maxConcurrentOperations = maxConcurrentOperations;
     _operationReferenceCount = 0;
     
@@ -250,7 +250,7 @@
 
 - (void)setMaxConcurrentOperations:(NSUInteger)maxConcurrentOperations
 {
-  NSAssert(maxConcurrentOperations > 1, @"Max concurrent operations must be greater than 1. If it's one, just use a serial queue!");
+  NSAssert(maxConcurrentOperations > 0, @"Max concurrent operations must be greater than 0.");
   [self lock];
     __block NSInteger difference = maxConcurrentOperations - _maxConcurrentOperations;
     _maxConcurrentOperations = maxConcurrentOperations;
@@ -335,9 +335,17 @@
         });
       }
     }
+  
+  NSInteger maxConcurrentOperations = _maxConcurrentOperations;
+  
   [self unlock];
   
   if (onlyCheckSerial) {
+    return;
+  }
+
+  //if only one concurrent operation is set, let's just use the serial queue for executing it
+  if (maxConcurrentOperations < 2) {
     return;
   }
   

--- a/Tests/PINOperationQueueTests.m
+++ b/Tests/PINOperationQueueTests.m
@@ -18,6 +18,7 @@ static NSTimeInterval PINOperationQueueTestBlockTimeout = 20;
 
 @end
 
+static const NSUInteger PINOperationQueueTestsLowestMaxOperations = 1;
 static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
 
 @implementation PINOperationQueueTests
@@ -173,6 +174,12 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
 - (void)testMaximumNumberOfConcurrentOperations
 {
   [self helperConfirmMaxOperations:PINOperationQueueTestsMaxOperations queue:self.queue];
+}
+
+- (void)testMaximumNumberOfConcurrentOperationsIsOne
+{
+  self.queue = [[PINOperationQueue alloc] initWithMaxConcurrentOperations:PINOperationQueueTestsLowestMaxOperations];
+  [self helperConfirmMaxOperations:PINOperationQueueTestsLowestMaxOperations queue:self.queue];
 }
 
 //We expect operations to run in priority order when added in that order as well


### PR DESCRIPTION
For now if the `maxConcurrentOperations` is set to 1 only use the serial queue for executing the operations one after another. We will not support any priority in this case. All of the operations will be executed in FIFO order added to the `_queuedOperations`.

See #2 