### PR TITLE
Ensure Group Calls Completion Block When Waiting

### DIFF
--- a/PINOperation.xcodeproj/project.pbxproj
+++ b/PINOperation.xcodeproj/project.pbxproj
@@ -139,7 +139,10 @@
 				CC0105571E27116600890935 /* Tests */,
 				CC01052E1E27110D00890935 /* Products */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
 		};
 		CC01052E1E27110D00890935 /* Products */ = {
 			isa = PBXGroup;

--- a/Source/PINOperationGroup.m
+++ b/Source/PINOperationGroup.m
@@ -58,7 +58,7 @@
 
 - (void)dealloc
 {
-    pthread_mutex_destroy(&_lock);
+  pthread_mutex_destroy(&_lock);
 }
 
 + (instancetype)asyncOperationGroupWithQueue:(PINOperationQueue *)operationQueue

--- a/Tests/PINOperationGroupTests.m
+++ b/Tests/PINOperationGroupTests.m
@@ -82,8 +82,13 @@ static NSTimeInterval PINOperationGroupTestBlockTimeout = 20;
       }
     }];
   }
-  
+  __block BOOL completionBlockCalled = NO;
+  [group setCompletion:^{
+    completionBlockCalled = YES;
+  }];
+
   [group waitUntilComplete];
+  XCTAssert(completionBlockCalled, @"Completion block should have been called after waiting.");
   
   @synchronized (self) {
     XCTAssert(operationsRun == 100, @"All operations should be run");


### PR DESCRIPTION
Resolves #9 . I removed the unused `_completionQueue` ivar since we currently don't have a policy around it.

This diff builds on top of #10 