### PR TITLE
Rename methods to avoid retain cycle warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master
-
 * Add your own contributions to the next release on the line below this with your name.
+* Deprecate addOperation: in favor of scheduleOperation: [garrett](https://github.com/garrettmoon)
 
 ## 1.0.0 -- 2017 January 10
 

--- a/Source/PINOperationGroup.m
+++ b/Source/PINOperationGroup.m
@@ -84,7 +84,7 @@
           dispatch_group_leave(_group);
         };
         
-        id <PINOperationReference> operationReference = [_operationQueue addOperation:groupBlock withPriority:[_operationPriorities[idx] unsignedIntegerValue]];
+        id <PINOperationReference> operationReference = [_operationQueue scheduleOperation:groupBlock withPriority:[_operationPriorities[idx] unsignedIntegerValue]];
         [_groupToOperationReferences setObject:operationReference forKey:_operationReferences[idx]];
       }
       

--- a/Source/PINOperationQueue.h
+++ b/Source/PINOperationQueue.h
@@ -50,7 +50,7 @@ PINOP_SUBCLASSING_RESTRICTED
  * @param operation The operation object to be added to the queue.
  *
  */
-- (id <PINOperationReference>)addOperation:(dispatch_block_t)operation;
+- (id <PINOperationReference>)scheduleOperation:(dispatch_block_t)operation;
 
 /**
  * Adds the specified operation object to the receiver.
@@ -60,7 +60,7 @@ PINOP_SUBCLASSING_RESTRICTED
  *
  * @discussion
  */
-- (id <PINOperationReference>)addOperation:(dispatch_block_t)operation withPriority:(PINOperationQueuePriority)priority;
+- (id <PINOperationReference>)scheduleOperation:(dispatch_block_t)operation withPriority:(PINOperationQueuePriority)priority;
 
 /**
  * Adds the specified operation object to the receiver.
@@ -74,12 +74,12 @@ PINOP_SUBCLASSING_RESTRICTED
  *
  * @discussion
  */
-- (id <PINOperationReference>)addOperation:(PINOperationBlock)operation
-                              withPriority:(PINOperationQueuePriority)priority
-                                identifier:(nullable NSString *)identifier
-                            coalescingData:(nullable id)coalescingData
-                       dataCoalescingBlock:(nullable PINOperationDataCoalescingBlock)dataCoalescingBlock
-                                completion:(nullable dispatch_block_t)completion;
+- (id <PINOperationReference>)scheduleOperation:(PINOperationBlock)operation
+                                   withPriority:(PINOperationQueuePriority)priority
+                                     identifier:(nullable NSString *)identifier
+                                 coalescingData:(nullable id)coalescingData
+                            dataCoalescingBlock:(nullable PINOperationDataCoalescingBlock)dataCoalescingBlock
+                                     completion:(nullable dispatch_block_t)completion;
 
 /**
  * The maximum number of queued operations that can execute at the same time.
@@ -122,6 +122,19 @@ PINOP_SUBCLASSING_RESTRICTED
  *
  */
 - (void)setOperationPriority:(PINOperationQueuePriority)priority withReference:(id <PINOperationReference>)reference;
+
+#pragma mark - Deprecated
+
+- (id <PINOperationReference>)addOperation:(dispatch_block_t)operation __deprecated_msg("Use scheduleOperation: instead.");
+
+- (id <PINOperationReference>)addOperation:(dispatch_block_t)operation withPriority:(PINOperationQueuePriority)priority __deprecated_msg("Use scheduleOperation:withPriority: instead.");
+
+- (id <PINOperationReference>)addOperation:(PINOperationBlock)operation
+                              withPriority:(PINOperationQueuePriority)priority
+                                identifier:(nullable NSString *)identifier
+                            coalescingData:(nullable id)coalescingData
+                       dataCoalescingBlock:(nullable PINOperationDataCoalescingBlock)dataCoalescingBlock
+                                completion:(nullable dispatch_block_t)completion __deprecated_msg("Use scheduleOperation:withPriority:identifier:coalescingData:dataCoalescingBlock:completion: instead.");
 
 @end
 

--- a/Source/PINOperationQueue.m
+++ b/Source/PINOperationQueue.m
@@ -148,12 +148,24 @@
   return reference;
 }
 
+// Deprecated
 - (id <PINOperationReference>)addOperation:(dispatch_block_t)block
 {
-  return [self addOperation:block withPriority:PINOperationQueuePriorityDefault];
+  return [self scheduleOperation:block];
 }
 
+- (id <PINOperationReference>)scheduleOperation:(dispatch_block_t)block
+{
+  return [self scheduleOperation:block withPriority:PINOperationQueuePriorityDefault];
+}
+
+// Deprecated
 - (id <PINOperationReference>)addOperation:(dispatch_block_t)block withPriority:(PINOperationQueuePriority)priority
+{
+  return [self scheduleOperation:block withPriority:priority];
+}
+
+- (id <PINOperationReference>)scheduleOperation:(dispatch_block_t)block withPriority:(PINOperationQueuePriority)priority
 {
   PINOperation *operation = [PINOperation operationWithBlock:^(id data) { block(); }
                                                    reference:[self nextOperationReference]
@@ -170,12 +182,28 @@
   return operation.reference;
 }
 
+// Deprecated
 - (id<PINOperationReference>)addOperation:(PINOperationBlock)block
                              withPriority:(PINOperationQueuePriority)priority
                                identifier:(NSString *)identifier
                            coalescingData:(id)coalescingData
                       dataCoalescingBlock:(PINOperationDataCoalescingBlock)dataCoalescingBlock
                                completion:(dispatch_block_t)completion
+{
+  return [self scheduleOperation:block
+                    withPriority:priority
+                      identifier:identifier
+                  coalescingData:coalescingData
+             dataCoalescingBlock:dataCoalescingBlock
+                      completion:completion];
+}
+
+- (id<PINOperationReference>)scheduleOperation:(PINOperationBlock)block
+                                  withPriority:(PINOperationQueuePriority)priority
+                                    identifier:(NSString *)identifier
+                                coalescingData:(id)coalescingData
+                           dataCoalescingBlock:(PINOperationDataCoalescingBlock)dataCoalescingBlock
+                                    completion:(dispatch_block_t)completion
 {
   id<PINOperationReference> reference = nil;
   BOOL isNewOperation = NO;

--- a/Tests/PINOperationQueueTests.m
+++ b/Tests/PINOperationQueueTests.m
@@ -49,7 +49,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
   
   for (NSUInteger count = 0; count < operationCount; count++) {
     dispatch_group_enter(group);
-    [self.queue addOperation:^{
+    [self.queue scheduleOperation:^{
       dispatch_group_leave(group);
     } withPriority:PINOperationQueuePriorityDefault];
   }
@@ -70,7 +70,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
       };
       
       [weakOperationPointers addPointer:(__bridge void * _Nullable)(operation)];
-      [self.queue addOperation:operation withPriority:PINOperationQueuePriorityDefault];
+      [self.queue scheduleOperation:operation withPriority:PINOperationQueuePriorityDefault];
     }
   }
   
@@ -94,7 +94,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
 
   __weak PINOperationQueueTests *weakSelf = self;
   for (NSUInteger count = 0; count < operationCount; count++) {
-    [self.queue addOperation:^{
+    [self.queue scheduleOperation:^{
       __strong PINOperationQueueTests *strongSelf = weakSelf;
       @synchronized (strongSelf) {
         operationsRun += 1;
@@ -114,12 +114,12 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
   __block NSInteger operationsRun = 0;
   for (NSUInteger count = 0; count < operationCount; count++) {
     __weak PINOperationQueueTests *weakSelf = self;
-    [self.queue addOperation:^{
+    [self.queue scheduleOperation:^{
       __strong PINOperationQueueTests *strongSelf = weakSelf;
       @synchronized (strongSelf) {
         operationsRun += 1;
       }
-      [strongSelf.queue addOperation:^{
+      [strongSelf.queue scheduleOperation:^{
         __strong PINOperationQueueTests *strongSelf = weakSelf;
         @synchronized (strongSelf) {
           operationsRun += 1;
@@ -145,7 +145,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
   for (NSUInteger count = 0; count < operationCount; count++) {
     dispatch_group_enter(group);
-    [queue addOperation:^{
+    [queue scheduleOperation:^{
       @synchronized (self) {
         runningOperationCount++;
         if (runningOperationCount == maxOperations) {
@@ -203,7 +203,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
   for (NSUInteger count = 0; count < highOperationCount; count++) {
     dispatch_group_enter(group);
-    [self.queue addOperation:^{
+    [self.queue scheduleOperation:^{
       usleep(10000);
       @synchronized (self) {
         ++highOperationComplete;
@@ -216,7 +216,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
   
   for (NSUInteger count = 0; count < defaultOperationCount; count++) {
     dispatch_group_enter(group);
-    [self.queue addOperation:^{
+    [self.queue scheduleOperation:^{
       usleep(10000);
       @synchronized (self) {
         ++defaultOperationComplete;
@@ -229,7 +229,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
   
   for (NSUInteger count = 0; count < lowOperationCount; count++) {
     dispatch_group_enter(group);
-    [self.queue addOperation:^{
+    [self.queue scheduleOperation:^{
       usleep(10000);
       @synchronized (self) {
         ++lowOperationComplete;
@@ -254,7 +254,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
   for (NSUInteger count = 0; count < PINOperationQueueTestsMaxOperations + 1; count++) {
-    [self.queue addOperation:^{
+    [self.queue scheduleOperation:^{
       [self recursivelyAddOperation];
     } withPriority:PINOperationQueuePriorityHigh];
   }
@@ -262,7 +262,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
   
   for (NSUInteger count = 0; count < operationCount; count++) {
     dispatch_group_enter(group);
-    [self.queue addOperation:^{
+    [self.queue scheduleOperation:^{
       dispatch_group_leave(group);
     } withPriority:PINOperationQueuePriorityLow];
   }
@@ -275,7 +275,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
-  [self.queue addOperation:^{
+  [self.queue scheduleOperation:^{
     [self recursivelyAddOperation];
   } withPriority:PINOperationQueuePriorityHigh];
 #pragma clang diagnostic pop
@@ -285,14 +285,14 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
 {
   const NSUInteger sleepTime = 100000;
   for (NSUInteger count = 0; count < PINOperationQueueTestsMaxOperations + 1; count++) {
-    [self.queue addOperation:^{
+    [self.queue scheduleOperation:^{
       usleep(sleepTime);
     } withPriority:PINOperationQueuePriorityDefault];
   }
   
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
-  id <PINOperationReference> operation = [self.queue addOperation:^{
+  id <PINOperationReference> operation = [self.queue scheduleOperation:^{
     XCTAssertTrue(NO, @"operation should have been canceled");
   } withPriority:PINOperationQueuePriorityDefault];
 #pragma clang diagnostics pop
@@ -314,7 +314,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
   for (NSUInteger count = 0; count < defaultOperationCount; count++) {
     dispatch_group_enter(group);
-    [self.queue addOperation:^{
+    [self.queue scheduleOperation:^{
       usleep(100);
       @synchronized (self) {
         ++defaultOperationComplete;
@@ -324,7 +324,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
   }
   
   dispatch_group_enter(group);
-  id <PINOperationReference> operation = [self.queue addOperation:^{
+  id <PINOperationReference> operation = [self.queue scheduleOperation:^{
     @synchronized (self) {
       //Make sure we're less than defaultOperationCount - PINOperationQueueTestsMaxOperations because this operation could start even while the others are running even
       //if started last.
@@ -359,7 +359,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
     // Fill up the queue with dummy operations so we have time to add real ones without them being unexpectedly executed
     for (NSUInteger i = 0; i < PINOperationQueueTestsMaxOperations * 2; i++) {
         dispatch_group_enter(group);
-        [self.queue addOperation:^{
+        [self.queue scheduleOperation:^{
             usleep(1000);
             dispatch_group_leave(group);
         }];
@@ -391,7 +391,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
             dispatch_group_leave(group);
         };
         
-        [self.queue addOperation:operation
+        [self.queue scheduleOperation:operation
                     withPriority:PINOperationQueuePriorityLow
                       identifier:identifier
                   coalescingData:nil
@@ -421,7 +421,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
     // Fill up the queue with dummy operations so we have time to add real ones without them being unexpectedly executed
     for (NSUInteger i = 0; i < PINOperationQueueTestsMaxOperations * 2; i++) {
         dispatch_group_enter(group);
-        [self.queue addOperation:^{
+        [self.queue scheduleOperation:^{
             usleep(1000);
             dispatch_group_leave(group);
         }];
@@ -446,7 +446,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
             dispatch_group_leave(group);
         };
         
-        [self.queue addOperation:operation
+        [self.queue scheduleOperation:operation
                     withPriority:PINOperationQueuePriorityLow
                       identifier:@"Identifier"
                   coalescingData:nil
@@ -472,7 +472,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
     // Fill up the queue with dummy operations so we have time to add real ones without them being unexpectedly executed
     for (NSUInteger i = 0; i < PINOperationQueueTestsMaxOperations * 2; i++) {
         dispatch_group_enter(group);
-        [self.queue addOperation:^{
+        [self.queue scheduleOperation:^{
             usleep(1000);
             dispatch_group_leave(group);
         }];
@@ -494,7 +494,7 @@ static const NSUInteger PINOperationQueueTestsMaxOperations = 5;
             dispatch_group_leave(group);
         };
         
-        [self.queue addOperation:operation
+        [self.queue scheduleOperation:operation
                     withPriority:PINOperationQueuePriorityLow
                       identifier:@"Identifier"
                   coalescingData:data


### PR DESCRIPTION
Clang is annoying and looks for retain cycles in methods which begin in `add` but aren't named `addOperationWithBlock`. Since adding a block to PINOperation is safe to do without doing the strongify weakify dance, lets rename to `schedule` so people don't have to type `addOperationWithBlock` every time.