### PR TITLE
Delete unused flag in operation group.

### DIFF
--- a/Source/PINOperationGroup.m
+++ b/Source/PINOperationGroup.m
@@ -28,7 +28,6 @@
   
   dispatch_block_t _completion;
   
-  BOOL _started;
   BOOL _canceled;
 }
 
@@ -75,7 +74,7 @@
 {
   [self lock];
     NSAssert(_canceled == NO, @"Operation group canceled.");
-    if (_started == NO && _canceled == NO) {
+    if (_canceled == NO) {
       for (NSUInteger idx = 0; idx < _operations.count; idx++) {
         dispatch_group_enter(_group);
         dispatch_block_t originalOperation = _operations[idx];
@@ -132,8 +131,8 @@
 {
   [self lock];
     id <PINGroupOperationReference> reference = nil;
-    NSAssert(_started == NO && _canceled == NO, @"Operation group already started or canceled.");
-    if (_started == NO && _canceled == NO) {
+    NSAssert(_canceled == NO, @"Operation group already canceled.");
+    if (_canceled == NO) {
       reference = [self locked_nextOperationReference];
       [_operations addObject:operation];
       [_operationPriorities addObject:@(priority)];
@@ -147,8 +146,8 @@
 - (void)setCompletion:(dispatch_block_t)completion
 {
   [self lock];
-    NSAssert(_started == NO && _canceled == NO, @"Operation group already started or canceled.");
-    if (_started == NO && _canceled == NO) {
+    NSAssert(_canceled == NO, @"Operation group already canceled.");
+    if (_canceled == NO) {
       _completion = completion;
     }
   [self unlock];


### PR DESCRIPTION
Thanks for `PINOperation` contribution to open source!

But I found a `_start` flag that never used, So I hope to remove it. 