### PR TITLE
Fixes coalesce operation race condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: Main workflow 
+
+on: [pull_request]
+
+jobs:
+  Lint:
+    name: Run Unit and Integration Tests (macOS)
+    runs-on: macOS-latest
+    steps:
+    - name: Checkout the Git repository
+      uses: actions/checkout@v1
+    - name: Setup dependencies
+      run: sudo gem install cocoapods danger danger-slack xcpretty
+    - name: Run Tests
+      run: make all 

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -1,0 +1,21 @@
+name: Main workflow 
+
+on:
+ push:
+    # Sequence of patterns matched against refs/heads
+    branches:
+      - master         # Push events on master branch
+      - 'releases/*'   # Push events to branches matching refs/heads/releases/*
+
+
+jobs:
+  Lint:
+    name: Run Unit and Integration Tests (macOS)
+    runs-on: macOS-latest
+    steps:
+    - name: Checkout the Git repository
+      uses: actions/checkout@v1
+    - name: Setup dependencies
+      run: sudo gem install cocoapods danger danger-slack xcpretty
+    - name: Run Tests
+      run: make all 


### PR DESCRIPTION
Even though `_identifierToOperations` is a weak-weak map, we still need to remove it when we removed operation. Otherwise, it may exists race condition which leads new added `completion` not be called for example.

A case:
Let's assume L384 and L213 runs concurrently, L384 executes firstly, then L213 executes, new added `completion` would not be called anymore.
https://github.com/zhongwuzw/PINOperation/blob/eed328e43f706fa9e4b2cc38e7ed1ba83dbb1c8c/Source/PINOperationQueue.m#L384

https://github.com/zhongwuzw/PINOperation/blob/eed328e43f706fa9e4b2cc38e7ed1ba83dbb1c8c/Source/PINOperationQueue.m#L213