### PR TITLE
Fix SPM support

### DIFF
--- a/PINOperation.podspec
+++ b/PINOperation.podspec
@@ -19,4 +19,5 @@ Pod::Spec.new do |s|
 EOS
   s.prefix_header_contents = pch_PIN
   s.source_files = 'Source/**/*.{h,m,mm}'
+  s.exclude_files = 'Source/include/**/*'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(name: "PINOperation", path: "Source", publicHeadersPath: "."),
+        .target(name: "PINOperation", path: "Source", publicHeadersPath: "include"),
         .testTarget(name: "PINOperationTests", dependencies: ["PINOperation"], path: "Tests")
     ]
 )

--- a/Source/include/PINOperation/PINOperation.h
+++ b/Source/include/PINOperation/PINOperation.h
@@ -1,0 +1,1 @@
+../../PINOperation.h

--- a/Source/include/PINOperation/PINOperationGroup.h
+++ b/Source/include/PINOperation/PINOperationGroup.h
@@ -1,0 +1,1 @@
+../../PINOperationGroup.h

--- a/Source/include/PINOperation/PINOperationMacros.h
+++ b/Source/include/PINOperation/PINOperationMacros.h
@@ -1,0 +1,1 @@
+../../PINOperationMacros.h

--- a/Source/include/PINOperation/PINOperationQueue.h
+++ b/Source/include/PINOperation/PINOperationQueue.h
@@ -1,0 +1,1 @@
+../../PINOperationQueue.h

--- a/Source/include/PINOperation/PINOperationTypes.h
+++ b/Source/include/PINOperation/PINOperationTypes.h
@@ -1,0 +1,1 @@
+../../PINOperationTypes.h


### PR DESCRIPTION
Hi,

Current release installed by SPM can't import headers as follows:

```
fatal error: 'PINOperation/PINOperation.h' file not found
#import <PINOperation/PINOperation.h>
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR fixes that.