### PR TITLE
Disable asserts in release builds when using Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,17 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(name: "PINOperation", path: "Source", publicHeadersPath: "."),
-        .testTarget(name: "PINOperationTests", dependencies: ["PINOperation"], path: "Tests")
+        .target(
+            name: "PINOperation", 
+            path: "Source", 
+            publicHeadersPath: ".",
+            cSettings: [
+                .define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release)),
+            ]),
+
+        .testTarget(
+            name: "PINOperationTests", 
+            dependencies: ["PINOperation"], 
+            path: "Tests")
     ]
 )


### PR DESCRIPTION
When using Swift Package Manager to integrate `PINOperation` into an app, Xcode does not automatically set `NS_BLOCK_ASSERTIONS` to `1` when building the package in release. This means that any `NSAsserts` that are hit in release cause crashes. This appears to only be an issue with [ObjC packages](https://forums.swift.org/t/assertions-in-swift-packages/42692). 

The change I've made is to `Package.swift` to set `NS_BLOCK_ASSERTIONS` to `1` when building in release.

(Note: I didn't actually hit an assert in this PINOperation, but the possibility is there)