### PR TITLE
Support Carthage xcframework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,7 @@ jobs:
     name: Carthage
     runs-on: macOS-latest
     env:
-      # Carthage is broken in Xcode 12 and above https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md
-      DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: carthage
@@ -48,7 +47,7 @@ jobs:
   swift-package-manager:
     runs-on: macos-latest
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,7 @@ XCODE_MAJOR_VERSION=$(shell xcodebuild -version | HEAD -n 1 | sed -E 's/Xcode ([
 .PHONY: all cocoapods test analyze carthage spm
 	
 carthage:
-	if [ ${XCODE_MAJOR_VERSION} -gt 11 ] ; then \
-		echo "Carthage no longer works in Xcode 12 https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md"; \
-		exit 1; \
-	fi
-	carthage build --no-skip-current
+	carthage build --no-skip-current --use-xcframeworks
 
 cocoapods:
 	pod lib lint


### PR DESCRIPTION
## WHY

- Carthage 0.38.0 supports`--use-xcframeworks` option.
- XCFramework resolves to Carthage Xcode 12 workaround.

## WHAT

- Fix missing xcode paths in GitHub Actions
  - https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
  - macOS-latest pre installs Xcode 13.2.1
- Remove Carthage workaround and use `--use-xcframeworks` option.